### PR TITLE
Users can filter endpoints by origin and/or destination

### DIFF
--- a/server/controller/trip.js
+++ b/server/controller/trip.js
@@ -126,6 +126,90 @@ class TripController {
       data: trips.rows,
     });
   }
+
+  /**
+   * Search for trips
+   * @staticmethod
+   * @param  {object} req - Request object
+   * @param {object} res - Response object
+   * @return {json} res.json
+   */
+  static async searchTrips(req, res) {
+    const {origin, destination} = req.query;
+
+    if (!origin && !destination) {
+      TripController.getAllTrips(req, res);
+    }else if (!origin && destination) {
+      TripController.searchTripsByDestination(destination, res)
+    }else if (origin && !destination) {
+       TripController.searchTripsByOrigin(origin, res)
+    }
+    else{
+      const trips = await pool.query(queryHelper.searchTrip, [origin, destination]);
+
+    if (trips.rowCount <= 0) {
+      return res.status(404).json({
+        status: 'error',
+        error: 'There are no trips',
+      });
+    }
+
+    return res.status(200).json({
+      status: 'success',
+      data: trips.rows,
+    });
+    }
+    
+    
+  }
+
+  /**
+   * Search for trips by origin
+   * @staticmethod
+   * @param  {object} req - Request object
+   * @param {object} res - Response object
+   * @return {json} res.json
+   */
+  static async searchTripsByOrigin(origin, res) {
+    
+    const trips = await pool.query(queryHelper.searchTripByOrigin, [origin]);
+
+    if (trips.rowCount <= 0) {
+      return res.status(404).json({
+        status: 'error',
+        error: 'There are no trips',
+      });
+    }
+
+    return res.status(200).json({
+      status: 'success',
+      data: trips.rows,
+    });
+  }
+
+   /**
+   * Search for trips by origin
+   * @staticmethod
+   * @param  {object} req - Request object
+   * @param {object} res - Response object
+   * @return {json} res.json
+   */
+  static async searchTripsByDestination(destination, res) {
+    
+    const trips = await pool.query(queryHelper.searchTripByDestination, [destination]);
+
+    if (trips.rowCount <= 0) {
+      return res.status(404).json({
+        status: 'error',
+        error: 'There are no trips',
+      });
+    }
+
+    return res.status(200).json({
+      status: 'success',
+      data: trips.rows,
+    });
+  }
 }
 
 export default TripController;

--- a/server/helper/query.js
+++ b/server/helper/query.js
@@ -16,7 +16,10 @@ const query = {
   adminBooking: 'SELECT * FROM booking',
   userBooking: 'SELECT * FROM booking WHERE user_id = $1',
   matchBooking: 'SELECT * FROM booking WHERE user_id = $1 AND booking_id = $2',
-  deleteBooking: 'DELETE FROM booking WHERE booking_id = $1'
+  deleteBooking: 'DELETE FROM booking WHERE booking_id = $1',
+  searchTrip: 'SELECT * FROM trip WHERE origin = $1 AND destination = $2',
+  searchTripByOrigin: 'SELECT * FROM trip WHERE origin = $1',
+  searchTripByDestination: 'SELECT * FROM trip WHERE destination = $1',
 };
 
 export default query;

--- a/server/route/trip.js
+++ b/server/route/trip.js
@@ -7,6 +7,7 @@ const router = express.Router();
 
 router.post('/', authorization.authorize, validate.add, trips.addTrip);
 router.delete('/:tripId', authorization.authorize, trips.cancelTrip);
-router.get('/', authorization.authorize, trips.getAllTrips);
+router.get('/', trips.getAllTrips);
+router.get('/search?', trips.searchTrips);
 
 export default router;

--- a/test/trip.js
+++ b/test/trip.js
@@ -11,6 +11,8 @@ let token = 'bearer ';
 let notAdmin = 'bearer ';
 let tripId;
 let busId;
+let origin;
+let destination;
 
 describe('Trips', () => {
   describe('Get tokens', () => {
@@ -310,7 +312,6 @@ describe('Trips', () => {
   });
 
   describe('DELETE /api/v1/trips/:tripId', () => {
-    console.log(tripId)
     it('should cancel a trip', (done) => {
       chai.request(app)
         .delete(`/api/v1/trips/${tripId}`)
@@ -407,6 +408,97 @@ describe('Trips', () => {
           done();
         });
     });
+  });
+
+  describe('GET /api/v1/trips/search?', () => {
+    it('should fetch all trips', (done) => {
+      chai.request(app)
+        .get('/api/v1/trips/search')
+        .set('authorization', token)
+        .then((res) => {
+          const { body } = res;
+          expect(res.status).to.equal(200);
+          expect(body).to.contain.property('status');
+          expect(body).to.contain.property('data');
+          expect(body.status).to.equal('success');
+          expect(body.data).to.be.an('array');
+          done();
+        });
+    });
+
+    it('should search for trips match query origin', (done) => {
+      chai.request(app)
+        .get('/api/v1/trips/search?origin=Ikeja')
+        .then((res) => {
+          const { body } = res;
+          expect(res.status).to.equal(200);
+          expect(body).to.contain.property('status');
+          expect(body).to.contain.property('data');
+          expect(body.status).to.equal('success');
+          expect(body.data).to.be.an('array');
+          done();
+        });
+    });
+
+    it('should search for trips match query destination', (done) => {
+      chai.request(app)
+        .get('/api/v1/trips/search?destination=CMS')
+        .then((res) => {
+          const { body } = res;
+          expect(res.status).to.equal(200);
+          expect(body).to.contain.property('status');
+          expect(body).to.contain.property('data');
+          expect(body.status).to.equal('success');
+          expect(body.data).to.be.an('array');
+          done();
+        });
+    });
+
+    it('should search for trips match query origin and destination', (done) => {
+      chai.request(app)
+        .get('/api/v1/trips/search?origin=Ikeja&destination=CMS')
+        .set('authorization', token)
+        .then((res) => {
+          const { body } = res;
+          expect(res.status).to.equal(200);
+          expect(body).to.contain.property('status');
+          expect(body).to.contain.property('data');
+          expect(body.status).to.equal('success');
+          expect(body.data).to.be.an('array');
+          done();
+        });
+    });
+
+    it("should return error if origin does not exist", (done) => {
+      chai.request(app)
+      .get(`/api/v1/trips/search?origin=none`)
+      .then((res) => {
+          const body = res.body;
+          expect(res.status).to.equal(404);
+          expect(body).to.contain.property('status');
+          expect(body).to.contain.property('error');
+          expect(body.status).to.equal("error");
+          expect(body.error).to.be.a("string");
+          expect(body.error).to.equal("There are no trips");
+          done()
+      })
+    });
+
+    it("should return error if destination does not exist", (done) => {
+      chai.request(app)
+      .get(`/api/v1/trips/search?destination=none`)
+      .then((res) => {
+          const body = res.body;
+          expect(res.status).to.equal(404);
+          expect(body).to.contain.property('status');
+          expect(body).to.contain.property('error');
+          expect(body.status).to.equal("error");
+          expect(body.error).to.be.a("string");
+          expect(body.error).to.equal("There are no trips");
+          done()
+      })
+    });
+
   });
 });
 
@@ -514,21 +606,7 @@ describe('Trips', () => {
 //             })
 //         });
 
-//         it("should return null if search query does not exist", (done) => {
-//             chai.request(app)
-//             .get(`/api/v1/trips/filter/origin?query=none`)
-//             .then((res) => {
-//                 const body = res.body;
-//                 expect(res.status).to.equal(404);
-//                 expect(body).to.contain.property('status');
-//                 expect(body).to.contain.property('error');
-//                 expect(body.status).to.equal("error");
-//                 expect(body.error).to.be.a("string");
-//                 expect(body.error).to.equal("No trip available");
-//                 done()
-//             })
-//         });
-//     });
+
 
 //     describe('GET /api/v1/trips/filter/destination?query=', () => {
 //         it('should return all the trips matching destination query',  (done) => {


### PR DESCRIPTION
What does this PR do?
Build filter trips by origin and destination endpoint

Description of Task to be completed?
Have the following endpoints working
`POST /api/v1/auth/signup`
`POST /api/v1/bus`
`POST /api/v1/trips`
`GET /api/v1/trips/search`

How should this be manually tested?
After cloning the repo and setting your environment variables, cd into the repo, run `npm run db` and then `npm run start:dev`

Using postman, test every endpoint above with this header
*key: Content-Type* *value: Application/json*
To test authentication, add this to the header: Get **token** from login endpoint
*key:authorization* *value: bearer* **token**
The endpoint takes origin and destination as query parameters

What are the relevant pivotal tracker stories? 
#167098297